### PR TITLE
feat: Make istio version optional, default to null

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,5 +5,5 @@ description: >
   base setup, including support for sidecar and ambient modes, and monitoring integration.
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "3.0.0" # The version of the OpenShift Service Mesh operator this chart is intended to be deployed upon

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Helm chart for deploying a fully functional Red Hat OpenShift Service Mesh 3.0 b
 | servicemesh.ossmc.spec.version | string | `"default"` |  |
 | servicemesh.peerauthentications | list | `[]` |  |
 | servicemesh.profile | string | `""` |  |
-| servicemesh.version | string | `"v1.24.3"` |  |
+| servicemesh.version | string | `nil` |  |
 | servicemesh.ztunnel.enabled | bool | `false` |  |
 | servicemesh.ztunnel.name | string | `"default"` |  |
 | servicemesh.ztunnel.values | object | `{}` |  |

--- a/templates/istio-cni.yaml
+++ b/templates/istio-cni.yaml
@@ -3,7 +3,9 @@ kind: IstioCNI
 metadata:
   name: {{ .Values.servicemesh.istiocni.name | quote }}
 spec:
+  {{- if .Values.servicemesh.version }}
   version: {{ .Values.servicemesh.version | quote }}
+  {{- end }}
   namespace: {{ .Values.servicemesh.istiocni.namespace | default .Release.Namespace | quote }}
   {{- if .Values.servicemesh.profile }}
   profile: {{ .Values.servicemesh.profile }}

--- a/templates/istio.yaml
+++ b/templates/istio.yaml
@@ -3,7 +3,9 @@ kind: Istio
 metadata:
   name: {{ .Values.servicemesh.istio.name | quote }}
 spec:
+  {{- if .Values.servicemesh.version }}
   version: {{ .Values.servicemesh.version | quote }}
+  {{- end }}
   namespace: {{ .Values.servicemesh.istio.namespace | default .Release.Namespace | quote }}
   {{- if .Values.servicemesh.profile }}
   profile: {{ .Values.servicemesh.profile }}

--- a/templates/ztunnel.yaml
+++ b/templates/ztunnel.yaml
@@ -4,7 +4,9 @@ kind: ZTunnel
 metadata:
   name: {{ .Values.servicemesh.ztunnel.name | quote }}
 spec:
+  {{- if .Values.servicemesh.version }}
   version: {{ .Values.servicemesh.version | quote }}
+  {{- end }}
   namespace: {{ .Values.servicemesh.ztunnel.namespace | default .Release.Namespace | quote }}
   {{- if .Values.servicemesh.profile }}
   profile: {{ .Values.servicemesh.profile | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 servicemesh:
-  version: v1.24.3
+  version: null
   profile: "" # Always applies default and openshift profiles, even when not set. If set, must be one of: ambient, default, demo, empty, openshift-ambient, openshift, preview, remote, stable.
 
   istio:


### PR DESCRIPTION
We let the operator fill in the default version in the related crds.
Keeping the value as optional so we can override and pin a version.
This allows us to update the operator more freely, w/o the need
